### PR TITLE
Return 0 for non-match in str_match

### DIFF
--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -4,5 +4,5 @@ function str_match($string, $pattern)
 {
     preg_match($pattern, $string, $matches);
 
-    return $matches[1] ?? false;
+    return $matches[1] ?? 0;
 }

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -4,5 +4,5 @@ function str_match($string, $pattern)
 {
     preg_match($pattern, $string, $matches);
 
-    return $matches[1];
+    return $matches[1] ?? 0;
 }

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -4,5 +4,5 @@ function str_match($string, $pattern)
 {
     preg_match($pattern, $string, $matches);
 
-    return $matches[1] ?? 0;
+    return $matches[1] ?? false;
 }


### PR DESCRIPTION
Checks to see if `$matches[1]` is set, if not returns `0` (same value as `preg_match` returns for non-match).

When using `str_match` in an if statement, `if(str_match())` an *Undefined offset: 1* notice is encountered. By checking for the match before returning it, we can avoid the notice. 