### PR TITLE
 Register string helpers as macros in Illuminate\Support\Str

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ stopwatch(function () {
 ```php
 str_between('--thing--', '--'); // returns "thing"
 str_between('[thing]', '[', ']'); // returns "thing"
+
+Str::between('--thing--', '--'); // returns "thing"
+Str::between('[thing]', '[', ']'); // returns "thing"
 ```
 
 
@@ -86,6 +89,8 @@ Because `preg_match` is annoying.
 
 str_match('Jan-1-2019', '/Jan-(.**)-2019/'); // returns "1"
 
+Str::match('Jan-1-2019', '/Jan-(.**)-2019/'); // returns "1"
+
 ```
 
 
@@ -95,6 +100,9 @@ A simple way to use validate a string using Laravel's built-in validation system
 ```php
 str_validate('calebporzio@aol.com', 'regex:/\.net$/|email|max:10');
 // returns: ["Format is invalid.", "May not be greater than 10 characters."]
+
+Str::validate('calebporzio@aol.com', 'regex:/\.net$/|email|max:10');
+// returns: ["Format is invalid.", "May not be greater than 10 characters."]
 ```
 
 
@@ -102,6 +110,8 @@ str_validate('calebporzio@aol.com', 'regex:/\.net$/|email|max:10');
 
 ```php
 str_wrap('thing', '--'); // returns "--thing--"
+
+Str::wrap('thing', '--'); // returns "--thing--"
 ```
 
 

--- a/src/AwesomeHelpersServiceProvider.php
+++ b/src/AwesomeHelpersServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace Calebporzio\AwesomeHelpers;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class AwesomeHelpersServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        Str::mixin(new StrMacros);
+
         foreach (scandir(__DIR__.DIRECTORY_SEPARATOR.'helpers') as $helperFile) {
             $path = sprintf(
                 '%s%s%s%s%s',

--- a/src/StrMacros.php
+++ b/src/StrMacros.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Calebporzio\AwesomeHelpers;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Validator;
+
+class StrMacros
+{
+    public function between()
+    {
+        return function ($subject, $beginning, $end = null) {
+            if (is_null($end)) {
+                $end = $beginning;
+            }
+            return Str::before(Str::after($subject, $beginning), $end);
+        };
+    }
+
+    public function match()
+    {
+        return function($string, $pattern) {
+            preg_match($pattern, $string, $matches);
+
+            return $matches[1] ?? false;
+        };
+    }
+
+    public function validate()
+    {
+        return function($data, $rules) {
+            return Collection::make(
+                Validator::make(['{placeholder}' => $data], ['{placeholder}' => $rules])
+                    ->errors()
+                    ->get('{placeholder}')
+            )->map(function ($message) {
+                return ucfirst(
+                    trim(
+                        str_replace('The {placeholder}', '',
+                            str_replace('The selected {placeholder}', 'This selection',
+                                $message)
+                        )
+                    )
+                );
+            });
+        };
+    }
+
+    public function wrap()
+    {
+        return function($value, $cap) {
+            return Str::start(Str::finish($value, $cap), $cap);
+        };
+    }
+}

--- a/src/StrMacros.php
+++ b/src/StrMacros.php
@@ -21,9 +21,11 @@ class StrMacros
     public function match()
     {
         return function($string, $pattern) {
-            preg_match($pattern, $string, $matches);
+            if (@preg_match($pattern, $string) === false) {
+                $pattern = '#'.preg_quote($pattern, '#').'#';
+            }
 
-            return $matches[1] ?? false;
+            return preg_match($pattern, $string) === 1;
         };
     }
 

--- a/src/helpers/str_between.php
+++ b/src/helpers/str_between.php
@@ -1,10 +1,8 @@
 <?php
 
+use Illuminate\Support\Str;
+
 function str_between($subject, $beginning, $end = null)
 {
-    if (is_null($end)) {
-        $end = $beginning;
-    }
-
-    return str_before(str_after($subject, $beginning), $end);
+    return Str::between($subject, $beginning, $end);
 }

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -4,5 +4,5 @@ function str_match($string, $pattern)
 {
     preg_match($pattern, $string, $matches);
 
-    return $matches[1] ?? 0;
+    return $matches[1] ?? false;
 }

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -1,8 +1,8 @@
 <?php
 
+use Illuminate\Support\Str;
+
 function str_match($string, $pattern)
 {
-    preg_match($pattern, $string, $matches);
-
-    return $matches[1] ?? false;
+    return Str::match($string, $pattern);
 }

--- a/src/helpers/str_validate.php
+++ b/src/helpers/str_validate.php
@@ -1,21 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 function str_validate($data, $rules)
 {
-    return collect(
-        Validator::make(['{placeholder}' => $data], ['{placeholder}' => $rules])
-            ->errors()
-            ->get('{placeholder}')
-    )->map(function ($message) {
-        return ucfirst(
-            trim(
-                str_replace('The {placeholder}', '',
-                    str_replace('The selected {placeholder}', 'This selection',
-                        $message)
-                )
-            )
-        );
-    });
+    return Str::validate($data, $rules);
 }

--- a/src/helpers/str_wrap.php
+++ b/src/helpers/str_wrap.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Support\Str;
+
 function str_wrap($value, $cap)
 {
-    return str_start(str_finish($value, $cap), $cap);
+    return Str::wrap($value, $cap);
 }


### PR DESCRIPTION
I thought it'd be neat if the string helpers were registered in the `Str` class so they could be used from there as well.