### PR TITLE
The return type of str_match should be boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ str_between('[thing]', '[', ']'); // returns "thing"
 Because `preg_match` is annoying.
 ```php
 
-str_match('Jan-1-2019', '/Jan-(.**)-2019/'); // returns "1"
+str_match('Jan-1-2019', '/Jan-(.*)-2019/'); // returns true
 
 ```
 

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -2,10 +2,8 @@
 
 function str_match($string, $pattern)
 {
-    $quotedDelimiter = preg_quote(substr($pattern, 0, 1), '#');
-
-    if (1 !== preg_match("#^($quotedDelimiter).*\\1[imsxeADSUXJu]*$#", $pattern)) {
-        $pattern = '#'.preg_quote($pattern, '#').'#';
+    if (false === @preg_match($pattern, $string)) {
+		$pattern = '#'.preg_quote($pattern, '#').'#';
     }
 
     return 1 === preg_match($pattern, $string);

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -2,7 +2,11 @@
 
 function str_match($string, $pattern)
 {
-    preg_match($pattern, $string, $matches);
+    $quotedDelimiter = preg_quote(substr($pattern, 0, 1), '#');
 
-    return $matches[1] ?? false;
+    if (1 !== preg_match("#^($quotedDelimiter).*\\1[imsxeADSUXJu]*$#", $pattern)) {
+        $pattern = '#'.preg_quote($pattern, '#').'#';
+    }
+
+    return 1 === preg_match($pattern, $string);
 }

--- a/src/helpers/str_match.php
+++ b/src/helpers/str_match.php
@@ -3,7 +3,7 @@
 function str_match($string, $pattern)
 {
     if (false === @preg_match($pattern, $string)) {
-		$pattern = '#'.preg_quote($pattern, '#').'#';
+	$pattern = '#'.preg_quote($pattern, '#').'#';
     }
 
     return 1 === preg_match($pattern, $string);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -72,11 +72,13 @@ class HelpersTest extends TestCase
     /** @test */
     function str_match()
     {
-        $this->assertEquals('something',
-            str_match('before something after', '/before (.*) after/')
-        );
+        $this->assertTrue(str_match('before something after', '/before (.*) after/'));
+        
+        $this->assertTrue(str_match('before something after', 'something'));
 
         $this->assertFalse(str_match('hidden', '/found/'));
+
+        $this->assertFalse(str_match('hidden', 'found'));
     }
 
     /** @test */


### PR DESCRIPTION
This commit at first was for fixing an issue `Undefined offset: 1` when the pattern gets matched, but it doesn't have a group to be captured.
When I think a little bit, I found that this function must return a boolean type due to the functionality of `preg_match` function ([Check the #Return Values](http://php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-returnvalues)), also it seems more legit because -think about it- we are here to asking about whether the string matches the regex or not.

I also added the ability to the developer to provide a normal search string (without pattern delimiters), and it will be converted to a regex pattern automatically.

For string extraction purposes, I suggest using another helper like `str_extract`.