### PR TITLE
Money doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ user()->posts()->create([...]);
 ```php
 echo money(12); // echoes "$12.00"
 echo money(12.75); // echoes "$12.75"
-echo money(12.75, false) // echos "$12"
-echo money(12.75, true, 'en_GB') // echos "£12"
+echo money(12.75, false); // echos "$13"
+echo money(12.75, true, 'en_GB'); // echos "£12.75"
 // Note: unless specified otherwise, money() will detect the current locale.
 ```
 


### PR DESCRIPTION
Couple of doc fixes for the money helper:

- Standardised use of semicolons
- Fixed rounding issue (screenshot)
- Fixed missing cents (screenshot)

<img width="375" alt="Screen Shot 2019-03-20 at 3 27 17 pm" src="https://user-images.githubusercontent.com/24803032/54659123-b5a66e80-4b24-11e9-9a64-ec4e88bc0485.png">
