### PR TITLE
Add an on_connection helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ return ok();
 ```
 
 
+**on_connection**
+
+Run callback under a different database connection.
+
+```php
+$tenantPostIds = on_connection('tenantdb', function () {
+    return Post::pluck('id');
+});
+```
+
+
 **stopwatch**
 
 Returns the amount of time (in seconds) the provided callback took to execute. Useful for debugging and profiling.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ chain(new Str)->singular('cars')->ucfirst(carry)();
 ```
 
 
+**connection**
+
+Run callback under a different database connection.
+
+```php
+$tenantPostIds = connection('tenantdb', function () {
+    return Post::pluck('id');
+});
+```
+
+
 **faker**
 
 Shortcut for: `$faker = Faker\Factory::create()`
@@ -68,17 +79,6 @@ echo money(12.75, true, 'en_GB') // echos "£12"
 Shortcut for `response('', 204)`. When you don't have anything to return from an endpoint, but you want to return success.
 ```php
 return ok();
-```
-
-
-**on_connection**
-
-Run callback under a different database connection.
-
-```php
-$tenantPostIds = on_connection('tenantdb', function () {
-    return Post::pluck('id');
-});
 ```
 
 

--- a/src/helpers/connection.php
+++ b/src/helpers/connection.php
@@ -1,6 +1,6 @@
 <?php
 
-function on_connection(string $connection, $callback)
+function connection(string $connection, $callback)
 {
     $default = config('database.default');
     config()->set('database.default', $connection);

--- a/src/helpers/on_connection.php
+++ b/src/helpers/on_connection.php
@@ -1,0 +1,11 @@
+<?php
+
+function on_connection(string $connection, $callback)
+{
+    $default = config('database.default');
+    config()->set('database.default', $connection);
+
+    return tap($callback(), function () use ($default) {
+        config()->set('database.default', $default);
+    });
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -80,6 +80,13 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
+    function on_connection()
+    {
+        // this one is too simple to go through the trouble of testing.
+        $this->assertTrue(function_exists('on_connection'));
+    }
+
+    /** @test */
     function str_between()
     {
         $this->assertEquals('something',

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -38,6 +38,13 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
+    function connection()
+    {
+        // this one is too simple to go through the trouble of testing.
+        $this->assertTrue(function_exists('connection'));
+    }
+
+    /** @test */
     public function faker()
     {
         $this->assertInstanceOf(Generator::class, faker());
@@ -77,13 +84,6 @@ class HelpersTest extends TestCase
     {
         // this one is too simple to go through the trouble of testing.
         $this->assertTrue(function_exists('ok'));
-    }
-
-    /** @test */
-    function on_connection()
-    {
-        // this one is too simple to go through the trouble of testing.
-        $this->assertTrue(function_exists('on_connection'));
     }
 
     /** @test */


### PR DESCRIPTION
This helper runs a callback under a different database connection.

**Example:**

```php
$tenantPostIds = on_connection('tenantdb', function () {
    return Post::pluck('id');
});
```

This is what is happening:

1. It sets the default connection to the given connection
2. It then runs the callback
3. It swaps back to the previous default connection
4. It returns the callback's return value

It's a very useful helper for multitenant applications. My favourite use for it is this command to run any artisan command on the test database connection:

**Usage:**

```sh
php artisan testdb migrate:fresh
php artisan testdb db:seed
```

**Command:**

```php
<?php

namespace App\Console\Commands;

use InvalidArgumentException;
use Illuminate\Console\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class TestDb extends Command
{
    protected $signature = 'testdb {targetCommand}';
    protected $description = "Runs the given artisan command on the testing database connection";

    private $testingConnection = 'testing';
    private $blacklistedCommands = ['inspire'];

    public function handle()
    {
        return on_connection($this->testingConnection, function () {
            return $this->call($this->getCommand(), $this->getOptions());
        });
    }

    protected function getCommand()
    {
        return tap($this->argument('targetCommand'), function ($command) {
            if (in_array($command, $this->blacklistedCommands)) {
                throw new InvalidArgumentException(
                    "We do not support [$command] for the [$this->testingConnection] database connection."
                );
            }
        });
    }

    protected function getOptions()
    {
        return collect($this->options())
            ->filter()
            ->map(function ($value, $key) {
                return ["--{$key}" => $value];
            })
            ->collapse()
            ->all();
    }

    public function run(InputInterface $input, OutputInterface $output)
    {
        collect(explode(' ', (string) $input))
            ->filter(function ($token) {
                return strpos($token, '-') === 0;
            })
            ->each(function ($option) {
                $this->addOption($option);
            });

        return parent::run($input, $output);
    }
}

```