### PR TITLE
Add toAssoc Macro to Collections

### DIFF
--- a/src/AwesomeHelpersServiceProvider.php
+++ b/src/AwesomeHelpersServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Calebporzio\AwesomeHelpers;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
@@ -10,6 +11,8 @@ class AwesomeHelpersServiceProvider extends ServiceProvider
     public function boot()
     {
         Str::mixin(new StrMacros);
+
+        Collection::mixin(new CollectionMacros);
 
         foreach (scandir(__DIR__.DIRECTORY_SEPARATOR.'helpers') as $helperFile) {
             $path = sprintf(

--- a/src/CollectionMacros.php
+++ b/src/CollectionMacros.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Calebporzio\AwesomeHelpers;
+
+
+class CollectionMacros
+{
+    public function toAssoc()
+    {
+        return function (){
+            return $this->reduce(function ($assoc, $keyValuePair) {
+                list($key, $value) = $keyValuePair;
+                $assoc[$key] = $value;
+                return $assoc;
+            }, new static);
+        };
+    }
+}

--- a/src/CollectionMacros.php
+++ b/src/CollectionMacros.php
@@ -6,7 +6,7 @@ namespace Calebporzio\AwesomeHelpers;
 
 class CollectionMacros
 {
-    public function toAssoc()
+    public function toAssoc ()
     {
         return function (){
             return $this->reduce(function ($assoc, $keyValuePair) {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -150,6 +150,22 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
+    public function toAssoc()
+    {
+        $ordered = collect([
+            ['name', 'John'],
+            ['lastName', 'Doe'],
+        ])->toAssoc();
+
+        $this->assertTrue(
+          collect([
+              'name' => 'something',
+              'lastName' => 'somethingElse',
+          ])->diffKeys($ordered)->count() === 0
+        );
+    }
+
+    /** @test */
     function tinker()
     {
         $mock = \Mockery::mock('overload:'.\Psy\Shell::class);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -158,10 +158,12 @@ class HelpersTest extends TestCase
         ])->toAssoc();
 
         $this->assertTrue(
-          collect([
-              'name' => 'something',
-              'lastName' => 'somethingElse',
-          ])->diffKeys($ordered)->count() === 0
+            $ordered->diffAssoc(
+                collect([
+                    'name' => 'John',
+                    'lastName' => 'Doe',
+                ])
+            )->count() === 0
         );
     }
 


### PR DESCRIPTION
It transform a pair of [key, value] into a collection of [ key => value ]

Example

```php
$assoc = collect([
            ['name', 'John'],
            ['lastName', 'Doe'],
])->toAssoc();

$assoc->all(); // returns ['name' => 'John', 'lastName' => 'Doe']
```
