### PR TITLE
Add dump_sql function compatibility with Eloquent Builder

### DIFF
--- a/src/helpers/dump_sql.php
+++ b/src/helpers/dump_sql.php
@@ -1,9 +1,14 @@
 <?php
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
-function dump_sql(Builder $builder)
+function dump_sql($builder)
 {
+    if(!(($builder instanceof Builder) || ($builder instanceof EloquentBuilder))) {
+        throw new TypeError('Argument passed to '.__METHOD__.'() should be instance of '.Builder::class.' or '.EloquentBuilder::class.'. '.get_class($builder).' given.');
+    }
+
     $sql = $builder->toSql();
     $bindings = $builder->getBindings();
 


### PR DESCRIPTION
Function dump_sql is currently allowing only DB Query Builder, it should allow Eloquent Builder too. 