### PR TITLE
More stable requiring helpers

### DIFF
--- a/src/AwesomeHelpersServiceProvider.php
+++ b/src/AwesomeHelpersServiceProvider.php
@@ -27,9 +27,11 @@ class AwesomeHelpersServiceProvider extends ServiceProvider
 
             $function = str_before($helperFile, '.php');
 
-            if (! function_exists($function)) {
-                require($path);
+            if (function_exists($function)) {
+                continue;
             }
+
+            require_once $path;
         }
     }
 }


### PR DESCRIPTION
+normal things don't deserve an if() - errors do
+require is a statement, not a function