### PR TITLE
fix carbon example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require calebporzio/awesome-helpers
 
 Shortcut for: `new Carbon` or `Carbon::parse()`
 ``` php
-carbon('One year ago');
+carbon('1 year ago');
 ```
 
 


### PR DESCRIPTION
`carbon('One year ago')` example gives the following error message:

Exception with message 'DateTime::__construct(): Failed to parse time string (One year ago) at position 0 (O): The timezone could not be found in the database'

This PR fixes that documentation problem.

