### PR TITLE
use glob() in order to include .php files

### DIFF
--- a/src/AwesomeHelpersServiceProvider.php
+++ b/src/AwesomeHelpersServiceProvider.php
@@ -11,27 +11,15 @@ class AwesomeHelpersServiceProvider extends ServiceProvider
     {
         Str::mixin(new StrMacros);
 
-        foreach (scandir(__DIR__.DIRECTORY_SEPARATOR.'helpers') as $helperFile) {
-            $path = sprintf(
-                '%s%s%s%s%s',
-                __DIR__,
-                DIRECTORY_SEPARATOR,
-                'helpers',
-                DIRECTORY_SEPARATOR,
-                $helperFile
-            );
+        foreach (glob(__DIR__ . '/helpers/*.php') as $helperFile) {
 
-            if (! is_file($path)) {
-                continue;
-            }
-
-            $function = Str::before($helperFile, '.php');
+            $function = Str::before(basename($helperFile), '.php');
 
             if (function_exists($function)) {
                 continue;
             }
 
-            require_once $path;
+            require_once $helperFile;
         }
     }
 }


### PR DESCRIPTION
By using `glob` only .php files are listed and, if it's the case, included.