### PR TITLE
Add helper first

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $tenantPostIds = connection('tenantdb', function () {
 
 Returns sql query with bindings data.
 ```php
-dump_sql(\DB::table('users')->where('email', "blaBla")->where('id', 1)); 
+dump_sql(\DB::table('users')->where('email', "blaBla")->where('id', 1));
 // returns "select * from `users` where `email` = 'blaBla' and `id` = 1"
 ```
 
@@ -63,6 +63,15 @@ faker()->address; // returns random, fake address
 faker('address'); // alternate syntax
 ```
 
+**first**
+
+Returns first element of arrays, collections, objects or a variable itself if it's a primitive value, similar to `end()`.\
+That's useful to avoid errors when acessing first positions of elements like `$variable[0]`.
+```php
+first('test'); //Returns 'test'
+first(['1', '2', '3']); //Returns '1'
+first([['a' => 1], ['b' => 2]]); //Returns ['a' => 1]
+```
 
 **user**
 

--- a/src/helpers/first.php
+++ b/src/helpers/first.php
@@ -1,0 +1,26 @@
+<?php
+
+function first($var)
+{
+    if(is_scalar($var) || $var === null) {
+        return $var;
+    }
+
+    if(is_array($var)) {
+        return isset(array_keys($var)[0]) ? ($var[array_keys($var)[0]]) : null;
+    }
+
+    if($var instanceof \Illuminate\Support\Collection) {
+        return isset($var[0]) ? $var[0] : $var;
+    }
+
+    if(is_object($var)) {
+        foreach($var as $v) {
+            if(is_array($v)) {
+                return $v;
+            }
+
+            return $var;
+        }
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -64,6 +64,38 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
+    public function first()
+    {
+        //Test on primitive types, should return themselves
+        $this->assertNull(first(null));
+        $this->assertTrue(first(true));
+        $this->assertFalse(first(false));
+        $this->assertEquals('', first(''));
+        $this->assertEquals('test-string', first('test-string'));
+        $this->assertEquals(1, first(1));
+
+        //Test on arrays, should return first position
+        $this->assertNull(first([]));
+        $this->assertEquals('1', first(['1', '2', '3']));
+        $this->assertEquals(1, first(['a' => 1, 'b' => 2]));
+        $this->assertEquals(['a' => 1, 'b' => 2], first([['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]]));
+
+        //Test on StdClass, should return itself if singleDimensional or first position if multiDimensional
+        $singleDimensionalStdClass = (object) ['a' => 1, 'b' => 2];
+        $this->assertEquals($singleDimensionalStdClass, first($singleDimensionalStdClass));
+
+        $multiDimensionalStdClass = (object) [['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]];
+        $this->assertEquals(['a' => 1, 'b' => 2], first($multiDimensionalStdClass));
+
+        //Test on collections, should return itself if singleDimensional or first position if multiDimensional
+        $singleDimensionalCollection = collect(['a' => 1, 'b' => 2]);
+        $this->assertEquals($singleDimensionalCollection, first($singleDimensionalCollection));
+
+        $multiDimensionalCollection = collect([['a' => 1, 'b' => 2], ['a' => 3, 'b' => 4]]);
+        $this->assertEquals($multiDimensionalCollection[0], first($multiDimensionalCollection));
+    }
+
+    /** @test */
     public function user()
     {
         // This one is too simple to go through the trouble of testing.


### PR DESCRIPTION
Add helper first, it returns first element of arrays, collections, objects or a variable itself if it's a primitive value, similar to `end()`.

That's useful to avoid errors when acessing first positions of elements like `$variable[0]`.