### PR TITLE
Simplified swap() function

### DIFF
--- a/src/helpers/swap.php
+++ b/src/helpers/swap.php
@@ -2,7 +2,5 @@
 
 function swap(&$a, &$b)
 {
-    $temp = $a;
-    $a = $b;
-    $b = $temp;
+    [$a, $b] = [$b, $a];
 }


### PR DESCRIPTION
PHP 7.1 introduced the short-hand list syntax, but this would also work with the list() construct.

This PR simply removes the temporary variable and instead uses the list syntax to swap the variables. Luckily, it works when you are passing variables through by reference, so no breaking changes and tests are all passing.