### PR TITLE
`map` function to loop through multiple arrays in parallel

### DIFF
--- a/src/helpers/arr.php
+++ b/src/helpers/arr.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Loop through multiple arrays in parallel
+ *
+ * @param Closure $callback
+ * @param iterable ...$arrays
+ * @return array
+ */
+if (!function_exists('map')) {
+    function map(\Closure $callback, ...$arrays)
+    {
+        $result = [];
+
+        foreach (array_map(null, ...$arrays) as $values) {
+            $result[] = call_user_func_array($callback, $values);
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
It will work like list comprehension in Elixir, Python

## Usage Example
```
$array1 = array(1,2,3);
$array2 = array(4,5,6);

$data = Illuminate\Support\Arr::map(function($item1, $item2) {
	    return $item1 * $item2;
}, $array1, $array2);

// [4,10,18]
```
### The helper can take variable number of arrays.