### PR TITLE
Utilize Laravel's getLocale method

### DIFF
--- a/src/helpers/money.php
+++ b/src/helpers/money.php
@@ -2,7 +2,7 @@
 
 function money($input, $showCents = true, $locale = null)
 {
-    setlocale(LC_MONETARY, $locale ?: locale_get_default());
+    setlocale(LC_MONETARY, $locale ?: app()->getLocale());
     
     $numberOfDecimalPlaces = $showCents ? 2 : 0;
 


### PR DESCRIPTION
Laravel's config/app.php configuration file allows users to specify a locale, however these settings are ignored when using the money() helper as it is reaching for the PHP locale instead. This PR switches to Laravel's app()->getLocale() method.